### PR TITLE
fix fused_seqpool_cvm_op_xpu op bug 

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_mean_op_xpu.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_mean_op_xpu.cc
@@ -90,6 +90,7 @@ class ReduceMeanGradXPUKernel : public framework::OpKernel<T> {
 
     bool reduce_all = ctx.Attr<bool>("reduce_all");
     auto reduce_dims = ctx.Attr<std::vector<int>>("dim");
+    bool keep_dim = ctx.Attr<bool>("keep_dim");
 
     std::vector<int> xdims;
     for (int i = 0; i < input->dims().size(); i++) {
@@ -112,6 +113,13 @@ class ReduceMeanGradXPUKernel : public framework::OpKernel<T> {
         d = d + xdims.size();
       }
       reduce_numel *= xdims[d];
+    }
+
+    if (keep_dim != true) {
+      sort(reduce_dims.begin(), reduce_dims.end());
+      for (auto& d : reduce_dims) {
+        ydims.insert(ydims.begin() + d, 1);
+      }
     }
 
     float val = 1.0f / static_cast<float>(reduce_numel);


### PR DESCRIPTION
fix  fix fused_seqpool_cvm_op_xpu op bug :

1 ) [Hint: Expected y_dims[1] % w == 0, but received y_dims[1] % w:18 != 0:0.] (at /workspace/Paddle/paddle/fluid/operators/fused/fused_seqpool_cvm_op_xpu.cc:103)
  [operator < fused_seqpool_cvm > error]. (at /workspace/Paddle/paddle/fluid/framework/threadpool.h:46)
![image](https://github.com/jack603047588/Paddle/assets/6914038/1d0493dd-ec67-44c9-b88a-1462a60e6509)

https://console.cloud.baidu-int.com/devops/icafe/issue/abacus-aibox-834/show?source=drawer-header

2)  [Hint: Expected y_dims[1] % (w-2) == 0, but received y_dims[1] % (w-2):64 != 0:0.] (at /workspace/workspace/Paddle/paddle/fluid/operators/fused/fused_seqpool_cvm_op_xpu.cc:109)
  [operator < fused_seqpool_cvm > error]. (at /workspace/workspace/Paddle/paddle/fluid/framework/threadpool.h:46)

https://console.cloud.baidu-int.com/devops/icafe/issue/abacus-aibox-835/show?source=drawer-header

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
