### PR TITLE
fix fused_seqpool_cvm_op_xpu op bug

### DIFF
--- a/paddle/fluid/operators/fused/fused_seqpool_cvm_op_xpu.cc
+++ b/paddle/fluid/operators/fused/fused_seqpool_cvm_op_xpu.cc
@@ -74,6 +74,7 @@ class FusedSeqpoolCVMOpXPUKernel : public framework::OpKernel<T> {
     auto clk_coeff = ctx.Attr<float>("clk_coeff");
     auto threshold = ctx.Attr<float>("threshold");
     auto cvm_offset = ctx.Attr<int>("cvm_offset");
+    auto embed_thres_size = ctx.Attr<int>("embed_thres_size");
 
     auto x0_lod = ins[0]->lod();
     auto x0_dims = ins[0]->dims();
@@ -98,12 +99,13 @@ class FusedSeqpoolCVMOpXPUKernel : public framework::OpKernel<T> {
     phi::Place l3_place = ctx.template device_context<DeviceContext>().GetL3Place();
     int w = ins[0]->numel() / x0_dims[0];
     if(use_cvm) {
+      if(clk_filter) w = w - 1;
       PADDLE_ENFORCE_EQ(y_dims[1] % w, 0,
                         paddle::platform::errors::InvalidArgument(
                             "The output of dims[1] should be dividable of w"));
     }
     else{
-      PADDLE_ENFORCE_EQ(y_dims[1] % (w-2), 0,
+      PADDLE_ENFORCE_EQ(y_dims[1] % (w - cvm_offset - embed_thres_size), 0,
                   paddle::platform::errors::InvalidArgument(
                       "The output of dims[1] should be dividable of (w-2)"));
     }


### PR DESCRIPTION
fix fix fused_seqpool_cvm_op_xpu op bug :

1 ) [Hint: Expected y_dims[1] % w == 0, but received y_dims[1] % w:18 != 0:0.] (at /workspace/Paddle/paddle/fluid/operators/fused/fused_seqpool_cvm_op_xpu.cc:103)
[operator < fused_seqpool_cvm > error]. (at /workspace/Paddle/paddle/fluid/framework/threadpool.h:46)
![image](https://github.com/jack603047588/Paddle/assets/6914038/49eddf6d-fc31-49f6-9846-db81828c4c88)

https://console.cloud.baidu-int.com/devops/icafe/issue/abacus-aibox-834/show?source=drawer-header

2) [Hint: Expected y_dims[1] % (w-2) == 0, but received y_dims[1] % (w-2):64 != 0:0.] (at /workspace/workspace/Paddle/paddle/fluid/operators/fused/fused_seqpool_cvm_op_xpu.cc:109)
[operator < fused_seqpool_cvm > error]. (at /workspace/workspace/Paddle/paddle/fluid/framework/threadpool.h:46)
https://console.cloud.baidu-int.com/devops/icafe/issue/abacus-aibox-835/show?source=drawer-header

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
