### PR TITLE
fix reduce_mean_op_xpu op bug for cvrq

### DIFF
--- a/paddle/fluid/operators/reduce_ops/reduce_mean_op_xpu.cc
+++ b/paddle/fluid/operators/reduce_ops/reduce_mean_op_xpu.cc
@@ -90,6 +90,7 @@ class ReduceMeanGradXPUKernel : public framework::OpKernel<T> {
 
     bool reduce_all = ctx.Attr<bool>("reduce_all");
     auto reduce_dims = ctx.Attr<std::vector<int>>("dim");
+    bool keep_dim = ctx.Attr<bool>("keep_dim");
 
     std::vector<int> xdims;
     for (int i = 0; i < input->dims().size(); i++) {
@@ -112,6 +113,13 @@ class ReduceMeanGradXPUKernel : public framework::OpKernel<T> {
         d = d + xdims.size();
       }
       reduce_numel *= xdims[d];
+    }
+
+    if (keep_dim != true) {
+      sort(reduce_dims.begin(), reduce_dims.end());
+      for (auto& d : reduce_dims) {
+        ydims.insert(ydims.begin() + d, 1);
+      }
     }
 
     float val = 1.0f / static_cast<float>(reduce_numel);


### PR DESCRIPTION
fix reduce_mean_op_xpu op bug for cvrq:

gtest_broadcast_mul<float>(api::kXPU2, "GM_0", "GM", "GM_0", {287, 990, 8}, {287, 990});
[ASSERT-FAIL](0==1)[src/wrapper/math_broadcast_calc_common.cpp:587]

ExternalError: XPU broadcast_mul kernel return wrong value[1 xpu api invalid param]
  [Hint: Expected r == XPU_SUCCESS, but received r:1 != XPU_SUCCESS:0.] (at /workspace/workspace/Paddle/paddle/fluid/operators/reduce_ops/reduce_mean_op_xpu.cc:138)
  [operator < reduce_mean_grad > error]. (at /workspace/workspace/Paddle/paddle/fluid/framework/threadpool.h:46)

Compile Traceback (most recent call last):
    File "./framework/train.py", line 352, in <module>
      update_model = model.Model(slot, False, config.update_model_lr, param_sgd_lr_map)
    File "./model.py", line 167, in __init__
      self._base_net(self.slot_data, self.label_cast)
    File "./model.py", line 640, in _base_net
      self._update_net()
    File "./model.py", line 422, in _update_net
      self.ctr_squeeze_input = self._squeeze_inputs(self.ctr_base_normalized, self.ctr_slot_stop[0]-self.ctr_slot_start[0], 11, ["mean", "max"], 8)
    File "./model.py", line 364, in _squeeze_inputs
      squeeze_tensor = paddle.mean(inputs_group, axis=2, keepdim=False)

<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
