### PR TITLE
remove redundant device context create in bkcl init flow.

### DIFF
--- a/paddle/fluid/platform/device/xpu/bkcl_helper.h
+++ b/paddle/fluid/platform/device/xpu/bkcl_helper.h
@@ -57,6 +57,10 @@ struct BKCLContext {
       : ctx_(new platform::XPUDeviceContext(XPUPlace(dev_id))),
         comm_{nullptr} {}
 
+  explicit BKCLContext(platform::Place place)
+      : ctx_(static_cast<platform::XPUDeviceContext*>(platform::DeviceContextPool::Instance().Get(place))),
+        comm_{nullptr} {}
+
   BKCLContext_t comm() const { return comm_; }
 
   int device_id() const { return ctx_->GetPlace().device; }
@@ -107,7 +111,7 @@ struct BKCLContextMap {
     for (auto &p : places_) {
       int dev_id = p.device;
       order_.emplace_back(dev_id);
-      contexts_.emplace(dev_id, BKCLContext(dev_id));
+      contexts_.emplace(dev_id, BKCLContext(p));
     }
     PADDLE_ENFORCE_EQ(
         order_.size(),


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->
Performance optimization

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->
Others 

### Describe
<!-- Describe what this PR does -->
删除bkcl init过程中多余的device context重复创建，节省因device context创建带来的load tune file时间消耗
