### PR TITLE
fix: lack of mfence in fused_seqpool_cvm_kernel

### DIFF
--- a/paddle/fluid/operators/fused/fused_seqpool_cvm_kernel.kps
+++ b/paddle/fluid/operators/fused/fused_seqpool_cvm_kernel.kps
@@ -648,7 +648,7 @@ struct do_sum_pooling_and_cvm {
                                         v_scale, 
                                         cur_x + i * in_dim_size);
         }
-
+        mfence();
         // second: cvm
         cvm_engine<T, embedx_concate_filter, use_cvm, clk_filter, T2>::cvm(local_result,
                                             seqid, out_dim_size,
@@ -701,7 +701,7 @@ struct do_sum_pooling_and_cvm_with_large_dim {
                                         v_scale, 
                                         cur_x + i * in_dim_size);
         }
-
+        mfence();
         // second: cvm
         cvm_engine<T, embedx_concate_filter, use_cvm, clk_filter, T2>::cvm(local_result,
                                             seqid, out_dim_size,


### PR DESCRIPTION
<!-- Demo: https://github.com/PaddlePaddle/Paddle/pull/24810 -->
### PR types
<!-- One of [ New features | Bug fixes | Function optimization | Performance optimization | Breaking changes | Others ] -->

### PR changes
<!-- One of [ OPs | APIs | Docs | Others ] -->

### Describe
<!-- Describe what this PR does -->
